### PR TITLE
Fix for hanging on quit (fixes issues #4 and #21 ) 

### DIFF
--- a/ga3c/ThreadPredictor.py
+++ b/ga3c/ThreadPredictor.py
@@ -24,6 +24,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import sys
+if sys.version_info >= (3,0):
+    from queue import Empty
+else:
+    from Queue import Empty
+
 from threading import Thread
 
 import numpy as np
@@ -47,7 +53,10 @@ class ThreadPredictor(Thread):
             dtype=np.float32)
 
         while not self.exit_flag:
-            ids[0], states[0] = self.server.prediction_q.get()
+            try: 
+                ids[0], states[0] = self.server.prediction_q.get(True, 0.001)
+            except Empty as e:
+                continue
 
             size = 1
             while size < Config.PREDICTION_BATCH_SIZE and not self.server.prediction_q.empty():

--- a/ga3c/ThreadTrainer.py
+++ b/ga3c/ThreadTrainer.py
@@ -24,6 +24,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import sys
+if sys.version_info >= (3,0):
+    from queue import Empty
+else:
+    from Queue import Empty
+
 from threading import Thread
 import numpy as np
 
@@ -43,7 +49,14 @@ class ThreadTrainer(Thread):
         while not self.exit_flag:
             batch_size = 0
             while batch_size <= Config.TRAINING_MIN_BATCH_SIZE:
-                x_, r_, a_ = self.server.training_q.get()
+                try:
+                    x_, r_, a_ = self.server.training_q.get(True, 0.001)
+                except Empty as e:
+                    # Check if trainer should quit 
+                    if self.exit_flag: 
+                        break
+                    continue
+                
                 if batch_size == 0:
                     x__ = x_; r__ = r_; a__ = a_
                 else:


### PR DESCRIPTION
Processes/threads got stuck in queue.get() operations which normally block indefinitely. This commit adds timeouts with required checks to quit when exit_flags are set to True. 
Added exit_flag for ProcessStats.
Added long timeout for receiving prediction in ProcessAgent. I don't see why this hangs at times but during tests there were rare cases where this part hanged.

The code "overshoots" the number of episodes defined in Config before closing. With EPISODES=10 my run reaches ~60 episodes before closing.

**Edit:** Actually this could be made better by using `multiprocessing.Queue.close`. It would still require try-excepts but would avoid using `get` every 0.001 seconds.