### PR TITLE
Replacing deprecated method

### DIFF
--- a/ga3c/Environment.py
+++ b/ga3c/Environment.py
@@ -35,6 +35,7 @@ import scipy.misc as misc
 
 from Config import Config
 from GameManager import GameManager
+import cv2
 
 
 class Environment:
@@ -55,7 +56,10 @@ class Environment:
     @staticmethod
     def _preprocess(image):
         image = Environment._rgb2gray(image)
-        image = misc.imresize(image, [Config.IMAGE_HEIGHT, Config.IMAGE_WIDTH], 'bilinear')
+        ## Below method was deprecated in newer versions of scipy
+        # image = misc.imresize(image, [Config.IMAGE_HEIGHT, Config.IMAGE_WIDTH], 'bilinear')
+        ## Alternative using cv2
+        image = cv2.resize(image, dsize=(Config.IMAGE_HEIGHT, Config.IMAGE_WIDTH), interpolation=cv2.INTER_LINEAR)
         image = image.astype(np.float32) / 128.0 - 1.0
         return image
 

--- a/ga3c/Environment.py
+++ b/ga3c/Environment.py
@@ -58,7 +58,7 @@ class Environment:
         image = Environment._rgb2gray(image)
         ## Below method was deprecated in newer versions of scipy
         # image = misc.imresize(image, [Config.IMAGE_HEIGHT, Config.IMAGE_WIDTH], 'bilinear')
-        ## Alternative using cv2
+        ## Alternative using cv2 
         image = cv2.resize(image, dsize=(Config.IMAGE_HEIGHT, Config.IMAGE_WIDTH), interpolation=cv2.INTER_LINEAR)
         image = image.astype(np.float32) / 128.0 - 1.0
         return image


### PR DESCRIPTION
With the newer version of scipy, they don't have resize() method.
Replacing it with OpenCV resize method.